### PR TITLE
Fix indentation for template variable

### DIFF
--- a/gen
+++ b/gen
@@ -85,33 +85,33 @@ EOF
 else
 
 touchpy() {
-cat << EOF
-  ${template}
-EOF
+cat <<[-]EOF
+${template}
+[-]EOF
 }
 
 touchpl() {
-cat << EOF
-  ${template}
-EOF
+cat <<[-]EOF
+${template}
+[-]EOF
 }
 
 touchc() {
-cat << EOF
-  ${template}
-EOF
+cat <<[-]EOF
+${template}
+[-]EOF
 }
 
 touchsh() {
-cat << EOF
-  ${template}
-EOF
+cat <<[-]EOF
+${template}
+[-]EOF
 }
 
 touchhtml() {
-cat << EOF
-  ${template}
-EOF
+cat <<[-]EOF
+${template}
+[-]EOF
 }
 fi
 

--- a/gen
+++ b/gen
@@ -115,8 +115,6 @@ ${template}
 }
 fi
 
-version="Generate (gen) version: 1.0"
-
 usage() {
 cat << EOF
 Usage: gen [OPTION]... [FILE]...


### PR DESCRIPTION
- Fixed indentation for template variable

This fix removes the leading tab/space on first line, without destroying the code syntax.