### PR TITLE
Typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ shellcheck gen
 - Don’t use `sed`.
     - Use `bash`'s built-in [parameter expansion](http://wiki.bash-hackers.org/syntax/pe).
 - Don’t use `cat`.
-    - Use `bash`'s built-in syntax (`file="$(< /path/to/file.txt)")`).
+    - Use `bash`'s built-in syntax (`file="$(< /path/to/file.txt)"`).
 - Don’t use `grep "pattern" | awk '{ printf }'`.
     - Use `awk '/pattern/ { printf }'`
 - Don’t use `wc`.


### PR DESCRIPTION
Removed extra brace on [#L48](https://github.com/membersincewayback/gen/blob/e2c88d/CONTRIBUTING.md?plain=1#L48) of CONTRIBUTING.md
