### PR TITLE
Edited `exists` function

### DIFF
--- a/gen
+++ b/gen
@@ -126,8 +126,8 @@ create_file() {
     if [[ -e "$FILENAME" ]]; then
         printf "Filename already exists.\n"; exit 1
     else
-        if ! touch "$FILENAME" 2> /dev/null; then
-            printf "Error: Couldn't touch \"$FILENAME\"\n\n" 
+        if ! touch "$FILENAME"; then
+            printf "\n" 
             usage 1
         fi
     fi

--- a/gen
+++ b/gen
@@ -104,7 +104,7 @@ Generate FILE, auto-input typical text, and auto-launch default editor.
 Full documentation <https://github.com/membersincewayback/gen>
 ${version}
 EOF
-exit
+exit $1
 }
 
 check_ext() {
@@ -124,10 +124,11 @@ check_ext() {
 
 exists() {
     if [[ -e "$FILENAME" ]]; then
-        printf "Filename already exists.\n"; exit
+        printf "Filename already exists.\n"; exit 1
     else
         if ! touch "$FILENAME" 2> /dev/null; then
-            usage
+            printf "Error: Couldn't touch \"$FILENAME\"\n\n" 
+            usage 1
         fi
     fi
 }

--- a/gen
+++ b/gen
@@ -122,7 +122,7 @@ check_ext() {
     esac
 }
 
-exists() {
+create_file() {
     if [[ -e "$FILENAME" ]]; then
         printf "Filename already exists.\n"; exit 1
     else
@@ -151,7 +151,7 @@ main() {
     EXT="${FILENAME#*.}"
     TEMPLATES="templates/template.${EXT}"
     get_args "$@"
-    exists
+    create_file
     check_ext
     [[ ! "${quiet}" ]] && \
         template_check && gen_"${format:-sh}" >> "${FILENAME}"

--- a/gen
+++ b/gen
@@ -104,7 +104,7 @@ Generate FILE, auto-input typical text, and auto-launch default editor.
 Full documentation <https://github.com/membersincewayback/gen>
 ${version}
 EOF
-exit $1
+exit "$1"
 }
 
 check_ext() {


### PR DESCRIPTION
#### - made `exists` exit erroneously  
We should probably return an error could if the file already exists  
Also, if touch fails (usually due to `EPERM` for us?)
then we should make it clear to the user that there was an error

I also edited `usage` slightly to return error codes when it needs to,  
it will continue to exit cleanly when nothing is passed

#### - renamed `exists`
`exists` doesn't simply check if the file exists, it will also create it,  
this new name might be more fitting

