### PR TITLE
provide chmod mode validation

### DIFF
--- a/gen
+++ b/gen
@@ -18,15 +18,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-readonly version="Generate (gen) version: 2.0.2 - July 31, 2023"
+readonly version="Generate (gen) version: 2.0.3 - August 3, 2023"
 
 usage() {
     printf "Usage: gen [OPTION]... [FILE]...\n"
     printf "Generate FILE, input script template, and launch default editor.\n\n"
-    printf "  -c,   customize file permissions ( gen -c 754 example.sh )\n"
+    printf "  -c,   change file permissions with octal mode bits ( gen -c 754 example.sh )\n"
     printf "  -d,   use default template despite available custom template\n"
     printf "  -e,   manually select editor ( gen -e nano example.py )\n"
-    printf "  -f,	overwrite existing file contents, never prompt\n"
+    printf "  -f,   overwrite existing file contents, never prompt\n"
     printf "  -h,   display help and exit\n"
     printf "  -q,   quiet automatic input of script template\n"
     printf "  -s,   suppress launch of editor\n"
@@ -60,7 +60,7 @@ gen_template() {
 }
 
 create_file() {
-    if [[ -f "$file" && -z "$force" ]]; then
+    if [[ -f "$file" && -z "${force:-}" ]]; then
         read -erp "gen: overwrite '${file}'? " overwrite
         [[ ! "${overwrite,,}" =~ ^y(es)?$ ]] && exit 0
     fi
@@ -92,15 +92,23 @@ get_template() {
 }
 
 get_args() {
-    while getopts ':hqfdsc:ve:' option; do
+    while getopts ':hqfdsvc:e:' option; do
         case "$option" in
             h) usage ;;
             q) quiet=true ;;
             f) force=true ;;
             d) default=true ;;
             s) suppress=true ;;
-            c) custom_mode="$OPTARG" ;;
             v) printf "%s\n" "$version"; exit 0 ;;
+            c) 
+                if [[ "$OPTARG" =~ [0-7]{3} ]]; then
+                    custom_mode="$OPTARG" 
+                else
+                    printf "gen: invalid mode: %s\n" "$OPTARG" >&2
+                    printf "Try 'gen -h' for more information.\n" >&2; exit 2
+                fi
+            ;;
+
             e)
                 if command -v "$OPTARG" &> /dev/null; then
                     editor="$OPTARG"

--- a/gen.1
+++ b/gen.1
@@ -1,4 +1,4 @@
-.TH GENERATE "1" "July 2023" "gen version: 2.0.0" "User Commands"
+.TH GENERATE "1" "August 2023" "gen version: 2.0.3" "User Commands"
 .SH NAME
 Generate \- create script using templates.
 .SH SYNOPSIS
@@ -8,16 +8,11 @@ Generate \- create script using templates.
 Create FILE, modify permissions, redirect script template to FILE, and launch default editor.
 .BR
 .TP
-.B chmod
-is used to set FILE permissions; if errors occur, an error message from\fB\ chmod\fR \c
-will be displayed.
-.BR
-.TP
 A FILE argument that exists will not be overwritten/modified, unless \fB\-f\fR is supplied.
 .SH OPTIONS
 .TP
 \fB\-c\fR,
-customize FILE permissions (\fB\ gen -c\fR 754 example.sh )
+change FILE permissions with octal mode bits (\fB\ gen -c\fR 754 example.sh )
 .BR
 .TP
 \fB\-d\fR,
@@ -57,11 +52,16 @@ Otherwise, PATH will be checked for\fB\ nano, vi, emacs, ed\fR (in order). The f
 .BR
 .TP
 If argument \fB\-e\fR is given,\fB\ gen\fR with search PATH for OPTARG.
-.SH "EXIT STATUS"
-If the exit statement is used with a value, then\fB\ gen\fR\ exits with the numeric value given to it.
+.SH "FILE PERMISSIONS"
+When applicable,\fB\ gen\fR uses\fB chmod\fR\ to give execute permissions to the user; if errors occur, an error message from\fB\ chmod\fR will be displayed.
 .BR
 .TP
-Otherwise, if there were no problems during execution,\fB\ gen\fR exits with the value\fB\ 0\fR.
+Otherwise, read & write permissions are set for the user to ensure minimum functionality. In either case, symbolic modes are used to promote least privilege ( u+rw ).
+.BR
+.TP
+Users however, are currently restricted to using octal modes when settings permissions with\fB\ gen\fR\ (\fB\ gen -c\fR\ 754 example.sh ). This is simply to facilitate input validation.
+.SH "EXIT STATUS"
+If there were no problems during execution,\fB\ gen\fR exits with the value\fB\ 0\fR.
 .BR
 .TP
 If an error occurs,\fB\ gen\fR exits with a non-zero value that may provide some context as below:


### PR DESCRIPTION
Made to address issue: https://github.com/zpiatt/gen/issues/22.

```bash
if [[ "$OPTARG" =~ [0-7]{3} ]]; then
    custom_mode="$OPTARG" 
else
    printf "gen: invalid mode: %s\n" "$OPTARG" >&2
    printf "Try 'gen -h' for more information.\n" >&2; exit 2
fi
```
Note: this limits mode selection to octal mode bits only. The attempt to validate symbolic mode bits with regex got complicated quickly...